### PR TITLE
Add homework class with ctex support and split templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,58 @@
-latex-homework-template
-=======================
+# LaTeX Homework Template (ctex fork)
 
-The LaTeX file that I use as the base for all my homeworks in university. You should follow [me on Twitter][twitter].
+本仓库在原始模板的基础上进行了最小必要的改动，主要目标是在保持原有排版风格的同时
+增加 XeLaTeX/`ctex` 的中文支持、可选的版式和字体配置，并将模板逻辑抽离成独立的
+`homework` 文档类，方便专注于正文编写。
 
-## Features
+## 目录结构
 
-Here are just a few features of this homework template.
+- `homework.cls`：统一的文档类，封装排版、页眉页脚、题目环境、可选的字体/行距/页边距
+  调整等功能。
+- `homework_en.tex`：英文示例正文，沿用原模板的排版示例。
+- `homework_zh-CN.tex`：中文示例正文，演示 `ctex` 中文支持及可选的中文标题等写法。
+- `images/`：沿用上游仓库的示意图片资源。
 
-1. Title page.
-2. Problem markers.
-3. Configurable problem numbers (see the last 3 problems for an example).
-4. Some commonly used math macros.
+## 主要改动
 
-## Screenshots
+1. **新增 `homework.cls` 文档类**：将原本写在 `homework.tex` 中的排版与宏命令集中到
+   文档类中。正文文件仅需引入 `\documentclass{homework}` 并设置作业元数据。
+2. **默认启用 `ctex`（`scheme=plain`）**：确保中文内容在 XeLaTeX 下直接可用，同时尽量
+   不干扰原有的英文字体设定。
+3. **可选的字体与版式接口**（默认关闭，示例以注释形式给出）：
+   - `\homeworksetlinespread{...}` 调整全文行距；
+   - `\homeworksetmargins{...}` 通过 `geometry` 重新设定页边距；
+   - `\homeworksetproblemtitlespacing{...}{...}` 控制 “Problem” 章节上下间距；
+   - `\homeworksetsolutionskip{...}{...}` 控制 `\solution` 标题前后的垂直间距；
+   - `\homeworksetCJKmainfont`、`\homeworksetmainfont` 等命令用于设置中文/西文字体；
+   - `\homeworksetmathfont` 会在需要时自动载入 `unicode-math`，用于指定数学字体。
+4. **提供中英文两份正文模板**：分别演示英文排版与中文排版的使用方式，其中中文模板也给
+   出了如何将 `Solution` 标题替换为“解答”的注释示例。
+5. **更新 `README.md`**：说明本分支的改动、使用方法以及与上游仓库的差异。
 
-### The Cover Page:
+## 使用方法
 
-![Cover page](/images/latex1.png)
-
-### Big Oh Example Problem:
-![Example problems 1](/images/latex2.png)
-
-### Automata & Pseudocode Problems:
-![Example problems 2](/images/latex3.png)
-
-### Statistics Problem:
-![Example problems 3](/images/latex4.png)
-
-### Proof Problem:
-![Example problems 4](/images/latex5.png)
-
-### Adjustable Problem Numbers
-![Example problem numbering](/images/latex6.png)
-
-## Installing
-
-1. First you'll need LaTeX. Instructions on obtaining it can be found here:
-   http://latex-project.org/ftp.html
-2. Compiling from the command line will look like the following:
+1. 建议使用 TeX Live 2025 及 XeLaTeX（或 LuaLaTeX），以获得完整的 `ctex` 与字体支持。
+2. 在命令行中使用 `latexmk` 进行自动编译，例如：
 
    ```bash
-   $ latexmk homework.tex
+   latexmk -xelatex homework_en.tex
+   latexmk -xelatex homework_zh-CN.tex
    ```
-3. Or you can use [TeXShop][texshop] or a similar native client to typeset the
-   LaTeX file.
 
-## Credit
+3. 若需要自定义版式或字体，可在正文文件中取消对应注释并填入所需参数。例如：
 
-When first starting with LaTeX, I came across [this template][credit] and used
-it as a base for starting my template. As you can see, it is pretty similar.
+   ```latex
+   % \homeworksetmargins{left=25mm,right=25mm,top=22mm,bottom=25mm}
+   % \homeworksetCJKmainfont{Source Han Serif SC}
+   % \homeworksetmathfont{XITS Math}
+   ```
 
-## License
+   需要注意：
+   - 指定数学字体时需确保系统已安装该字体；
+   - `\homeworksetmathfont` 会加载 `unicode-math`，与传统的 `mathptmx` 等方案不同。
 
-This code is distributed under the MIT license. For more info, read the
-[LICENSE](/LICENSE) file distributed with the source code.
+4. 中文模板中如果希望将 `Solution` 改为“解答”，可按照文件中给出的注释进行 `\renewcommand`。
 
-[texshop]: http://pages.uoregon.edu/koch/texshop/
-[credit]: http://www.latextemplates.com/template/programming-coding-assignment
-[twitter]: https://twitter.com/jldavis
+## 许可协议
+
+本仓库继续沿用上游模板的 [MIT 许可证](LICENSE)。

--- a/homework.cls
+++ b/homework.cls
@@ -1,0 +1,153 @@
+% Homework assignment class based on the original template
+% Provides XeLaTeX/ctex support and configurable layout hooks
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{homework}[2024/05/08 Homework assignment class]
+
+\LoadClass{article}
+
+% Encoding and font support
+\RequirePackage{ifxetex}
+\RequirePackage{ifluatex}
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0
+  \ClassError{homework}{The homework class requires XeLaTeX or LuaLaTeX}{Compile this document with XeLaTeX (recommended) or LuaLaTeX.}
+\fi
+\RequirePackage[scheme=plain]{ctex}
+\RequirePackage{fontspec}
+
+% Mathematics and algorithm packages
+\RequirePackage{amsmath}
+\RequirePackage{amsthm}
+\RequirePackage{amsfonts}
+\RequirePackage{tikz}
+\usetikzlibrary{automata,positioning}
+\RequirePackage[plain]{algorithm}
+\RequirePackage{algpseudocode}
+
+% Header/footer and section formatting
+\RequirePackage{fancyhdr}
+\RequirePackage{extramarks}
+\RequirePackage{titlesec}
+\PassOptionsToPackage{pass}{geometry}
+\RequirePackage{geometry}
+\RequirePackage{etoolbox}
+
+% Default layout closely follows the original template
+\setlength{\topmargin}{-0.45in}
+\setlength{\evensidemargin}{0in}
+\setlength{\oddsidemargin}{0in}
+\setlength{\textwidth}{6.5in}
+\setlength{\textheight}{9.0in}
+\setlength{\headsep}{0.25in}
+\setlength{\headheight}{14pt}
+\linespread{1.1}\selectfont
+\setlength{\parindent}{0pt}
+
+% Optional layout adjustment helpers (disabled by default)
+% Users may uncomment the corresponding commands in their documents.
+\newcommand{\homeworksetlinespread}[1]{\linespread{#1}\selectfont}
+\newcommand{\homeworksetmargins}[1]{\geometry{#1}}
+\newcommand{\homeworksetproblemtitlespacing}[2]{\titlespacing*{\section}{0pt}{#1}{#2}}
+
+% Solution heading spacing controls
+\newlength{\hmwkSolutionBeforeSkip}
+\newlength{\hmwkSolutionAfterSkip}
+\setlength{\hmwkSolutionBeforeSkip}{0.5\baselineskip}
+\setlength{\hmwkSolutionAfterSkip}{0.5\baselineskip}
+\newcommand{\homeworksetsolutionskip}[2]{%
+  \setlength{\hmwkSolutionBeforeSkip}{#1}%
+  \setlength{\hmwkSolutionAfterSkip}{#2}%
+}
+\newcommand{\solution}{%
+  \par\vspace{\hmwkSolutionBeforeSkip}%
+  \textbf{\large Solution}%
+  \par\vspace{\hmwkSolutionAfterSkip}%
+}
+
+% Font customization helpers (optional)
+\newcommand{\homeworksetCJKmainfont}[2][]{\setCJKmainfont[#1]{#2}}
+\newcommand{\homeworksetCJKsansfont}[2][]{\setCJKsansfont[#1]{#2}}
+\newcommand{\homeworksetCJKmonofont}[2][]{\setCJKmonofont[#1]{#2}}
+\newcommand{\homeworksetmainfont}[2][]{\setmainfont[#1]{#2}}
+\newcommand{\homeworksetsansfont}[2][]{\setsansfont[#1]{#2}}
+\newcommand{\homeworksetmonofont}[2][]{\setmonofont[#1]{#2}}
+\makeatletter
+\newcommand{\homeworksetmathfont}[2][]{%
+  \@ifpackageloaded{unicode-math}{%
+    \setmathfont[#1]{#2}%
+  }{%
+    \RequirePackage{unicode-math}%
+    \setmathfont[#1]{#2}%
+  }%
+}
+\makeatother
+
+% Fancyhdr configuration
+\pagestyle{fancy}
+\fancyhf{}
+\lhead{\hmwkAuthorName}
+\chead{\hmwkClass\ (\hmwkClassInstructor\ \hmwkClassTime): \hmwkTitle}
+\rhead{\firstxmark}
+\lfoot{\lastxmark}
+\cfoot{\thepage}
+\renewcommand\headrulewidth{0.4pt}
+\renewcommand\footrulewidth{0.4pt}
+
+% Problem section helpers
+\newcommand{\enterProblemHeader}[1]{%
+  \nobreak\extramarks{}{Problem \arabic{#1} continued on next page\ldots}\nobreak{}
+  \nobreak\extramarks{Problem \arabic{#1} (continued)}{Problem \arabic{#1} continued on next page\ldots}\nobreak{}
+}
+\newcommand{\exitProblemHeader}[1]{%
+  \nobreak\extramarks{Problem \arabic{#1} (continued)}{Problem \arabic{#1} continued on next page\ldots}\nobreak{}
+  \stepcounter{#1}%
+  \nobreak\extramarks{Problem \arabic{#1}}{}\nobreak{}
+}
+
+\setcounter{secnumdepth}{0}
+\newcounter{partCounter}
+\newcounter{homeworkProblemCounter}
+\setcounter{homeworkProblemCounter}{1}
+\nobreak\extramarks{Problem \arabic{homeworkProblemCounter}}{}\nobreak{}
+
+\newenvironment{homeworkProblem}[1][-1]{%
+  \ifnum#1>0
+    \setcounter{homeworkProblemCounter}{#1}%
+  \fi
+  \section{Problem \arabic{homeworkProblemCounter}}
+  \setcounter{partCounter}{1}%
+  \enterProblemHeader{homeworkProblemCounter}%
+}{%
+  \exitProblemHeader{homeworkProblemCounter}%
+}
+
+% Metadata defaults (users should redefine in their documents)
+\newcommand{\hmwkTitle}{Homework}
+\newcommand{\hmwkDueDate}{}
+\newcommand{\hmwkClass}{Course Name}
+\newcommand{\hmwkClassTime}{Class Time}
+\newcommand{\hmwkClassInstructor}{Instructor}
+\newcommand{\hmwkAuthorName}{Author}
+
+\renewcommand{\part}[1]{\textbf{\large Part \Alph{partCounter}}\stepcounter{partCounter}\\}
+
+% Title page configuration
+\title{%
+  \vspace{2in}%
+  \textmd{\textbf{\hmwkClass:\ \hmwkTitle}}\\
+  \normalsize\vspace{0.1in}\small{Due\ on\ \hmwkDueDate}\
+  \vspace{0.1in}\large{\textit{\hmwkClassInstructor\ \hmwkClassTime}}%
+  \vspace{3in}%
+}
+\author{\hmwkAuthorName}
+\date{}
+
+% Helper macros
+\newcommand{\alg}[1]{\textsc{\bfseries \footnotesize #1}}
+\newcommand{\deriv}[1]{\frac{\mathrm{d}}{\mathrm{d}x} (#1)}
+\newcommand{\pderiv}[2]{\frac{\partial}{\partial #1} (#2)}
+\newcommand{\dx}{\mathrm{d}x}
+\newcommand{\E}{\mathrm{E}}
+\newcommand{\Var}{\mathrm{Var}}
+\newcommand{\Cov}{\mathrm{Cov}}
+\newcommand{\Bias}{\mathrm{Bias}}
+

--- a/homework_en.tex
+++ b/homework_en.tex
@@ -1,139 +1,20 @@
-\documentclass{article}
+\documentclass{homework}
 
-\usepackage{fancyhdr}
-\usepackage{extramarks}
-\usepackage{amsmath}
-\usepackage{amsthm}
-\usepackage{amsfonts}
-\usepackage{tikz}
-\usepackage[plain]{algorithm}
-\usepackage{algpseudocode}
+% Optional configuration examples (uncomment to enable):
+% \homeworksetlinespread{1.15}
+% \homeworksetmargins{left=1in,right=1in,top=0.85in,bottom=1in}
+% \homeworksetproblemtitlespacing{*2}{*1}
+% \homeworksetsolutionskip{0.75\baselineskip}{0.5\baselineskip}
+% \homeworksetmainfont{Times New Roman}
+% \homeworksetCJKmainfont{SimSun}
+% \homeworksetmathfont{Latin Modern Math}
 
-\usetikzlibrary{automata,positioning}
-
-%
-% Basic Document Settings
-%
-
-\topmargin=-0.45in
-\evensidemargin=0in
-\oddsidemargin=0in
-\textwidth=6.5in
-\textheight=9.0in
-\headsep=0.25in
-
-\linespread{1.1}
-
-\pagestyle{fancy}
-\lhead{\hmwkAuthorName}
-\chead{\hmwkClass\ (\hmwkClassInstructor\ \hmwkClassTime): \hmwkTitle}
-\rhead{\firstxmark}
-\lfoot{\lastxmark}
-\cfoot{\thepage}
-
-\renewcommand\headrulewidth{0.4pt}
-\renewcommand\footrulewidth{0.4pt}
-
-\setlength\parindent{0pt}
-
-%
-% Create Problem Sections
-%
-
-\newcommand{\enterProblemHeader}[1]{
-    \nobreak\extramarks{}{Problem \arabic{#1} continued on next page\ldots}\nobreak{}
-    \nobreak\extramarks{Problem \arabic{#1} (continued)}{Problem \arabic{#1} continued on next page\ldots}\nobreak{}
-}
-
-\newcommand{\exitProblemHeader}[1]{
-    \nobreak\extramarks{Problem \arabic{#1} (continued)}{Problem \arabic{#1} continued on next page\ldots}\nobreak{}
-    \stepcounter{#1}
-    \nobreak\extramarks{Problem \arabic{#1}}{}\nobreak{}
-}
-
-\setcounter{secnumdepth}{0}
-\newcounter{partCounter}
-\newcounter{homeworkProblemCounter}
-\setcounter{homeworkProblemCounter}{1}
-\nobreak\extramarks{Problem \arabic{homeworkProblemCounter}}{}\nobreak{}
-
-%
-% Homework Problem Environment
-%
-% This environment takes an optional argument. When given, it will adjust the
-% problem counter. This is useful for when the problems given for your
-% assignment aren't sequential. See the last 3 problems of this template for an
-% example.
-%
-\newenvironment{homeworkProblem}[1][-1]{
-    \ifnum#1>0
-        \setcounter{homeworkProblemCounter}{#1}
-    \fi
-    \section{Problem \arabic{homeworkProblemCounter}}
-    \setcounter{partCounter}{1}
-    \enterProblemHeader{homeworkProblemCounter}
-}{
-    \exitProblemHeader{homeworkProblemCounter}
-}
-
-%
-% Homework Details
-%   - Title
-%   - Due date
-%   - Class
-%   - Section/Time
-%   - Instructor
-%   - Author
-%
-
-\newcommand{\hmwkTitle}{Homework\ \#2}
-\newcommand{\hmwkDueDate}{February 12, 2014}
-\newcommand{\hmwkClass}{Calculus}
-\newcommand{\hmwkClassTime}{Section A}
-\newcommand{\hmwkClassInstructor}{Professor Isaac Newton}
-\newcommand{\hmwkAuthorName}{\textbf{Josh Davis} \and \textbf{Davis Josh}}
-
-%
-% Title Page
-%
-
-\title{
-    \vspace{2in}
-    \textmd{\textbf{\hmwkClass:\ \hmwkTitle}}\\
-    \normalsize\vspace{0.1in}\small{Due\ on\ \hmwkDueDate\ at 3:10pm}\\
-    \vspace{0.1in}\large{\textit{\hmwkClassInstructor\ \hmwkClassTime}}
-    \vspace{3in}
-}
-
-\author{\hmwkAuthorName}
-\date{}
-
-\renewcommand{\part}[1]{\textbf{\large Part \Alph{partCounter}}\stepcounter{partCounter}\\}
-
-%
-% Various Helper Commands
-%
-
-% Useful for algorithms
-\newcommand{\alg}[1]{\textsc{\bfseries \footnotesize #1}}
-
-% For derivatives
-\newcommand{\deriv}[1]{\frac{\mathrm{d}}{\mathrm{d}x} (#1)}
-
-% For partial derivatives
-\newcommand{\pderiv}[2]{\frac{\partial}{\partial #1} (#2)}
-
-% Integral dx
-\newcommand{\dx}{\mathrm{d}x}
-
-% Alias for the Solution section header
-\newcommand{\solution}{\textbf{\large Solution}}
-
-% Probability commands: Expectation, Variance, Covariance, Bias
-\newcommand{\E}{\mathrm{E}}
-\newcommand{\Var}{\mathrm{Var}}
-\newcommand{\Cov}{\mathrm{Cov}}
-\newcommand{\Bias}{\mathrm{Bias}}
+\renewcommand{\hmwkTitle}{Homework\ \#2}
+\renewcommand{\hmwkDueDate}{February 12, 2014}
+\renewcommand{\hmwkClass}{Calculus}
+\renewcommand{\hmwkClassTime}{Section A}
+\renewcommand{\hmwkClassInstructor}{Professor Isaac Newton}
+\renewcommand{\hmwkAuthorName}{\textbf{Josh Davis} \and \textbf{Davis Josh}}
 
 \begin{document}
 
@@ -151,7 +32,7 @@
         \item \(f(n) = n^2 - n + 1\), \(g(n) = n^2 / 2\)
     \end{enumerate}
 
-    \textbf{Solution}
+    \solution
 
     We solve each solution algebraically to determine a possible constant
     \(c\).

--- a/homework_zh-CN.tex
+++ b/homework_zh-CN.tex
@@ -1,0 +1,105 @@
+\documentclass{homework}
+
+% 可选的版式/字体配置示例（默认关闭，按需取消注释）：
+% \homeworksetlinespread{1.2}
+% \homeworksetmargins{left=2.6cm,right=2.6cm,top=2.2cm,bottom=2.4cm}
+% \homeworksetproblemtitlespacing{*1.8}{*1}
+% \homeworksetsolutionskip{0.6\baselineskip}{0.5\baselineskip}
+% \homeworksetCJKmainfont{Source Han Serif SC}
+% \homeworksetmainfont{Times New Roman}
+% \homeworksetmathfont{XITS Math}
+
+\renewcommand{\hmwkTitle}{第 1 次作业}
+\renewcommand{\hmwkDueDate}{2025 年 3 月 15 日}
+\renewcommand{\hmwkClass}{数值分析}
+\renewcommand{\hmwkClassTime}{周三 3-4 节}
+\renewcommand{\hmwkClassInstructor}{张老师}
+\renewcommand{\hmwkAuthorName}{张三}
+
+% 如需将“Solution”标题替换为中文，可按需启用：
+% \renewcommand{\solution}{\par\vspace{\hmwkSolutionBeforeSkip}\textbf{解答}\par\vspace{\hmwkSolutionAfterSkip}}
+
+\begin{document}
+
+\maketitle
+
+\pagebreak
+
+\begin{homeworkProblem}
+    设存在正的常数 \(c\)，使得当 \(n>1\) 时 \(f(n) \leq c\cdot g(n)\)。
+    求满足条件的常数 \(c\)。
+
+    \begin{enumerate}
+        \item \(f(n) = n^2 + n + 1\)，\(g(n) = 2n^3\)
+        \item \(f(n) = n\sqrt{n} + n^2\)，\(g(n) = n^2\)
+        \item \(f(n) = n^2 - n + 1\)，\(g(n) = n^2 / 2\)
+    \end{enumerate}
+
+    \solution
+
+    对每一小问分别估计上界即可求得一个可行的 \(c\)。
+
+    \textbf{小问一}
+
+    \[
+        \begin{split}
+            n^2 + n + 1
+            &\leq n^2 + n^2 + n^2\\
+            &= 3n^2\\
+            &\leq 2c\, n^3
+        \end{split}
+    \]
+
+    取 \(c = 2\) 即可满足条件。
+
+    \textbf{小问二}
+
+    \[
+        \begin{split}
+            n^2 + n\sqrt{n}
+            &= n^2 + n^{3/2}\\
+            &\leq n^2 + n^{4/2}\\
+            &= 2n^2\\
+            &\leq c\, n^2
+        \end{split}
+    \]
+
+    取 \(c = 2\) 即可。
+
+    \textbf{小问三}
+
+    \[
+        \begin{split}
+            n^2 - n + 1
+            &\leq n^2\\
+            &\leq \tfrac{1}{2}c\, n^2
+        \end{split}
+    \]
+
+    仍可令 \(c = 2\)。
+\end{homeworkProblem}
+
+\pagebreak
+
+\begin{homeworkProblem}
+    证明多项式
+    \(P(n) = a_kn^k + a_{k-1}n^{k-1} + \cdots + a_0\)
+    （其中 \(a_i \geq 0\)）属于 \(\Theta(n^k)\)。
+
+    \solution
+
+    因为每个系数均非负，故有
+    \(P(n) \geq a_kn^k\)，于是 \(P(n) = \Omega(n^k)\)。
+    另一方面，利用多项式的单调性可得
+
+    \[
+        P(n)
+        \leq (a_k + a_{k-1} + \cdots + a_0) n^k,
+    \]
+
+    从而存在常数 \(c_2 = a_k + \cdots + a_0\)，使得
+    \(P(n) \leq c_2 n^k\)，即 \(P(n) = O(n^k)\)。
+    结合上下界可知 \(P(n) = \Theta(n^k)\)。
+\end{homeworkProblem}
+
+\end{document}


### PR DESCRIPTION
## Summary
- add a reusable `homework` class with built-in ctex support plus optional layout and font helpers
- migrate the original example into `homework_en.tex` and provide a new Chinese sample `homework_zh-CN.tex`
- refresh the README to document the fork-specific changes and usage instructions

## Testing
- `latexmk -xelatex homework_en.tex` *(fails: `latexmk` not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1860700308323924232280acd08f6